### PR TITLE
Adds basic lein support using borkdude/lein2deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 <!-- ### Changed -->
 <!-- ### Removed -->
 
+## [0.2.0] - 2023-06-21
+
+### Added
+
+- Added basic lein support using [lein2deps](https://github.com/borkdude/lein2deps)
+
 ## [0.1.9] - 2023-04-15
 
 ### Added
@@ -25,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 - First public release
 
-[unreleased]: https://github.com/scarletcomply/license-finder/compare/v0.1.9...HEAD
+[unreleased]: https://github.com/scarletcomply/license-finder/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/scarletcomply/license-finder/compare/v0.1.9...v0.2.0
 [0.1.9]: https://github.com/scarletcomply/license-finder/compare/v0.1.5...v0.1.9
 [0.1.5]: https://github.com/scarletcomply/license-finder/releases/tag/v0.1.5

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-`license-finder` is a Clojure library that finds the licenses of the dependencies used in your Clojure(Script) projects. The library supports `deps.edn`, `shadow-cljs.edn`, and `package.json` (with npm's `package-lock.json`). With it, you can easily generate a report of the licenses used by your project's dependencies, making it easier to comply with open source licenses and legal requirements.
+`license-finder` is a Clojure library that finds the licenses of the dependencies used in your Clojure(Script) projects. The library supports `deps.edn`, `shadow-cljs.edn`, `package.json` (with npm's `package-lock.json`) and `project.clj` (Using Borkdude's lein2deps to convert the project and extract licenses). With it, you can easily generate a report of the licenses used by your project's dependencies, making it easier to comply with open source licenses and legal requirements.
 
 
 ## Use Cases
@@ -87,13 +87,13 @@ Releases are available from [Clojars][clojars].
 deps.edn:
 
 ```clojure
-com.scarletcomply/license-finder {:mvn/version "0.1.9"}
+com.scarletcomply/license-finder {:mvn/version "0.2.0"}
 ```
 
 Leiningen/Boot:
 
 ```clojure
-[com.scarletcomply/license-finder "0.1.9"]
+[com.scarletcomply/license-finder "0.2.0"]
 ```
 
 ## License

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,7 @@
 {:paths ["src" "resources"]
  :deps  {babashka/fs                   {:mvn/version "0.3.17"}
+         io.github.borkdude/lein2deps  {:git/url "https://github.com/borkdude/lein2deps"
+                                        :git/sha "aaea9dcbb6ef18982d6989d67370e71d7cf6ec86"}
          io.github.clojure/tools.build {:mvn/version "0.9.4"}
          org.clojure/data.csv          {:mvn/version "1.0.1"}
          org.clojure/data.json         {:mvn/version "2.4.0"}

--- a/src/scarlet/license_finder/deps.clj
+++ b/src/scarlet/license_finder/deps.clj
@@ -1,7 +1,8 @@
 (ns scarlet.license-finder.deps
   (:require [babashka.fs :as fs]
-            [scarlet.license-finder.deps.shadow-cljs :as shadow-cljs]
+            [scarlet.license-finder.deps.lein :as lein]
             [scarlet.license-finder.deps.npm :as npm]
+            [scarlet.license-finder.deps.shadow-cljs :as shadow-cljs]
             [scarlet.license-finder.deps.tools-deps :as tools-deps]))
 
 (defmulti find-dependencies
@@ -39,3 +40,7 @@
 (defmethod find-dependencies "package.json"
   [file-path opts]
   (npm/find-dependencies file-path opts))
+
+(defmethod find-dependencies "project.clj"
+  [file-path opts]
+  (lein/find-dependencies file-path opts))

--- a/src/scarlet/license_finder/deps/lein.clj
+++ b/src/scarlet/license_finder/deps/lein.clj
@@ -1,0 +1,14 @@
+(ns scarlet.license-finder.deps.lein
+  (:require [babashka.fs :as fs]
+            [clojure.tools.deps.alpha :as deps]
+            [lein2deps.api :as lein-deps]
+            [scarlet.license-finder.deps.tools-deps :as tools-deps]))
+
+(defn find-dependencies
+  "Collects Clojure dependencies from a lein `project.clj` file."
+  [file-path opts]
+  (let [path (fs/absolutize file-path)]
+    (-> (lein-deps/lein2deps {:project-clj (str path)})
+        :deps
+        deps/calc-basis
+        (tools-deps/basis-deps opts))))


### PR DESCRIPTION
This aims to add some basic support to lein projects converting the `project.clj` into a deps basis and then passing it to tools.deps to analyze de dependencies and list it's licenses.

Closes: https://github.com/scarletcomply/license-finder/issues/2