### PR TITLE
Fix to find license *files*, esp in deps dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
       - uses: ./.github/actions/setup
       - run: bb test
       - run: bb jar

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+clojure 1.12.0.1530
+babashka 1.12.197

--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ You can then generate a license report via the command line:
 Licenses written to target/licenses/deps.edn.csv
 ```
 
+
+### As an alias
+
+If you don't want to or cannot install license-finder as a tool, you can use from `deps.edn` as an alias:
+
+``` clojure
+:build/extract-licenses
+{:replace-deps {com.github.scarletcomply/license-finder {:git/tag "v0.3.0"
+                                                         :git/sha "16e0560"}}
+ :exec-fn      scarlet.license-finder.tool/report}
+```
+
+OR
+
+``` clojure
+:build/extract-licenses
+{:replace-deps {com.github.scarletcomply/license-finder {:git/tag "v0.3.0"
+                                                         :git/sha "16e0560"}}
+ :exec-fn      scarlet.license-finder.tool/report
+ :exec-args    {:transitive? true}}
+```
+
+Use like this: `clojure -X:build/extract-licenses :out '"./deps.edn.csv"'`
+
 ## Installation
 
 Releases are available from [Clojars][clojars].

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,15 @@
 {:paths ["src" "resources"]
- :deps  {babashka/fs                   {:mvn/version "0.3.17"}
+ :deps  {babashka/fs                   {:mvn/version "0.5.24"}
          io.github.borkdude/lein2deps  {:mvn/version "0.1.1"}
-         io.github.clojure/tools.build {:mvn/version "0.9.4"}
-         org.clojure/data.csv          {:mvn/version "1.0.1"}
-         org.clojure/data.json         {:mvn/version "2.4.0"}
-         org.clojure/tools.deps.alpha  {:mvn/version "0.15.1254"}}
+         io.github.clojure/tools.build {:mvn/version "0.10.8"}
+         org.clojure/data.csv          {:mvn/version "1.1.0"}
+         org.clojure/data.json         {:mvn/version "2.5.1"}
+         org.clojure/tools.deps        {:mvn/version "0.23.1512"}}
  :aliases {:dev    {:extra-paths ["dev"]}
            :test   {:extra-paths ["test"]}
-           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.80.1274"}}
+           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
                     :main-opts  ["-m" "kaocha.runner"]}
-           :build  {:deps {io.github.clojure/tools.build {:mvn/version "0.9.3"}
-                           slipset/deps-deploy           {:mvn/version "0.2.0"}}
+           :build  {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+                           slipset/deps-deploy           {:mvn/version "0.2.2"}}
                     :ns-default build}}
  :tools/usage {:ns-default scarlet.license-finder.tool}}

--- a/src/scarlet/license_finder/deps/lein.clj
+++ b/src/scarlet/license_finder/deps/lein.clj
@@ -1,6 +1,6 @@
 (ns scarlet.license-finder.deps.lein
   (:require [babashka.fs :as fs]
-            [clojure.tools.deps.alpha :as deps]
+            [clojure.tools.deps :as deps]
             [lein2deps.api :as lein-deps]
             [scarlet.license-finder.deps.tools-deps :as tools-deps]))
 

--- a/src/scarlet/license_finder/deps/shadow_cljs.clj
+++ b/src/scarlet/license_finder/deps/shadow_cljs.clj
@@ -1,8 +1,8 @@
 (ns scarlet.license-finder.deps.shadow-cljs
   (:require [babashka.fs :as fs]
             [clojure.edn :as edn]
-            [clojure.tools.deps.alpha :as deps]
-            [clojure.tools.deps.alpha.util.dir :as deps-dir]
+            [clojure.tools.deps :as deps]
+            [clojure.tools.deps.util.dir :as deps-dir]
             [scarlet.license-finder.deps.tools-deps :as tools-deps]))
 
 (defn- read-edn [file]

--- a/src/scarlet/license_finder/deps/tools_deps.clj
+++ b/src/scarlet/license_finder/deps/tools_deps.clj
@@ -1,8 +1,8 @@
 (ns scarlet.license-finder.deps.tools-deps
   (:require [babashka.fs :as fs]
-            [clojure.tools.deps.alpha :as deps]
-            [clojure.tools.deps.alpha.extensions :as deps-ext]
-            [clojure.tools.deps.alpha.util.dir :as deps-dir]))
+            [clojure.tools.deps :as deps]
+            [clojure.tools.deps.extensions :as deps-ext]
+            [clojure.tools.deps.util.dir :as deps-dir]))
 
 (defn basis-deps
   "Returns a seq of deps maps from a basis map."

--- a/src/scarlet/license_finder/detect.clj
+++ b/src/scarlet/license_finder/detect.clj
@@ -24,7 +24,9 @@
    glob `patterns`."
   [^FileSystem fs dir-path patterns]
   (let [matchers (map (fn [^String pattern]
-                        (.getPathMatcher fs (str "glob:" pattern)))
+                        ;; The path that will be matched against the pattern contains a full canonicalPath.
+                        ;; The patterns must therefore cater for the dir-path prefix, when setting up the glob
+                        (.getPathMatcher fs (str "glob:" dir-path java.io.File/separator pattern)))
                       patterns)
         matches? (fn [^Path path]
                    (some (fn [^PathMatcher m]


### PR DESCRIPTION
## Bug report

For dependencies specified by git coordinates, license-finder does not find `LICENSE` files.

### Diagnosis and fix

- The PathMatcher contains a glob pattern to scan for certain well-known file names in a folder
- This pattern was specified is `(str "glob:" pattern)`.
- This glob will not work, as the `Path` being matched, will contain a canonical-path (ie full filesystem path)
- The glob pattern will not match on this.

This fix is to add the `dir-path` to the front of the constructed glob, after which the existing glob patterns will match license files in that directory

## Extras

This PR contains extra "improvements". Feel free to reject any of these:
- Add a section to the `README` with instructions of using `license-finder` with `clojure -X:...` in the `deps.edn` project dir. This is useful for my use-case, where I do not want to install license-finder as a clojure tool.
- Routine update to Github `actions/checkout@v4.2.2`
- Update all dependencies, including the non-alpha version of `tools.deps`. Fix namespace requires.
- BONUS: Add a `.tool-versions` file ([asdf](https://asdf-vm.com/)) that specifies (most-recent) versions of `clojure` and `babashka`, of which at least recent versions are required for these changes to work.